### PR TITLE
Fix typo in END_WITHOUT_START_TAG

### DIFF
--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -89,7 +89,7 @@ class LogStash::Filters::Elapsed < LogStash::Filters::Base
 
   ELAPSED_TAG = "elapsed"
   EXPIRED_ERROR_TAG = PREFIX + "expired_error"
-  END_WITHOUT_START_TAG = PREFIX + "end_wtihout_start"
+  END_WITHOUT_START_TAG = PREFIX + "end_without_start"
   MATCH_TAG = PREFIX + "match"
 
   config_name "elapsed"

--- a/spec/filters/elapsed_spec.rb
+++ b/spec/filters/elapsed_spec.rb
@@ -105,7 +105,7 @@ describe LogStash::Filters::Elapsed do
 
             @filter.filter(end_event)
 
-            insist { end_event["tags"].include?("elapsed.end_wtihout_start") } == true
+            insist { end_event["tags"].include?("elapsed.end_without_start") } == true
           end
         end
       end


### PR DESCRIPTION
Trying to help moving PR https://github.com/elastic/logstash-contrib/pull/92 using
````
curl -L -s https://github.com/elastic/logstash-contrib/pull/92.patch | git am --3way
````
Moved from https://github.com/elastic/logstash-contrib/pull/92/files

hoping @knoxilla already signed the CLA ;)

