### PR TITLE
Use _ instead of . in field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 3.0.0
+ - Elasticsearch 2.0 does not allow field names with dots in them.  This is a
+   breaking change which replaces the `.` with an underscore, `_`
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -65,24 +65,24 @@ require 'socket'
 # "end event" or a new "match event" can be created. Both events store the
 # following information:
 #
-# * the tags `elapsed` and `elapsed.match`
-# * the field `elapsed.time` with the difference, in seconds, between
+# * the tags `elapsed` and `elapsed_match`
+# * the field `elapsed_time` with the difference, in seconds, between
 #   the two events timestamps
 # * an ID filed with the task ID
-# * the field `elapsed.timestamp_start` with the timestamp of the start event
+# * the field `elapsed_timestamp_start` with the timestamp of the start event
 #
 # If the "end event" does not arrive before "timeout" seconds, the
 # "start event" is discarded and an "expired event" is generated. This event
 # contains:
 #
-# * the tags `elapsed` and `elapsed.expired_error`
-# * a field called `elapsed.time` with the age, in seconds, of the
+# * the tags `elapsed` and `elapsed_expired_error`
+# * a field called `elapsed_time` with the age, in seconds, of the
 #   "start event"
 # * an ID filed with the task ID
-# * the field `elapsed.timestamp_start` with the timestamp of the "start event"
+# * the field `elapsed_timestamp_start` with the timestamp of the "start event"
 #
 class LogStash::Filters::Elapsed < LogStash::Filters::Base
-  PREFIX = "elapsed."
+  PREFIX = "elapsed_"
   ELAPSED_FIELD = PREFIX + "time"
   TIMESTAMP_START_EVENT_FIELD = PREFIX + "timestamp_start"
   HOST_FIELD = "host"
@@ -131,7 +131,7 @@ class LogStash::Filters::Elapsed < LogStash::Filters::Base
   end
 
   def filter(event)
-    
+
 
     unique_id = event[@unique_id_field]
     return if unique_id.nil?

--- a/logstash-filter-elapsed.gemspec
+++ b/logstash-filter-elapsed.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elapsed'
-  s.version         = '2.0.2'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter tracks a pair of start/end events and calculates the elapsed time between them."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -24,4 +24,3 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
 end
-

--- a/spec/filters/elapsed_spec.rb
+++ b/spec/filters/elapsed_spec.rb
@@ -100,12 +100,12 @@ describe LogStash::Filters::Elapsed do
 
       describe "and with an id" do
         describe "but without a previous 'start event'" do
-          it "adds a tag 'elapsed.end_witout_start' to the 'end event'" do
+          it "adds a tag 'elapsed_end_witout_start' to the 'end event'" do
             end_event = end_event(ID_FIELD => "id_123")
 
             @filter.filter(end_event)
 
-            insist { end_event["tags"].include?("elapsed.end_without_start") } == true
+            insist { end_event["tags"].include?("elapsed_end_without_start") } == true
           end
         end
       end
@@ -153,16 +153,16 @@ describe LogStash::Filters::Elapsed do
               insist { @match_event["tags"].include?("elapsed") } == true
             end
 
-            it "contains the tag tag 'elapsed.match'" do
-              insist { @match_event["tags"].include?("elapsed.match") } == true
+            it "contains the tag tag 'elapsed_match'" do
+              insist { @match_event["tags"].include?("elapsed_match") } == true
             end
 
-            it "contains an 'elapsed.time field' with the elapsed time" do
-              insist { @match_event["elapsed.time"] } == 10
+            it "contains an 'elapsed_time field' with the elapsed time" do
+              insist { @match_event["elapsed_time"] } == 10
             end
 
-            it "contains an 'elapsed.timestamp_start field' with the timestamp of the 'start event'" do
-              insist { @match_event["elapsed.timestamp_start"] } == @start_event["@timestamp"]
+            it "contains an 'elapsed_timestamp_start field' with the timestamp of the 'start event'" do
+              insist { @match_event["elapsed_timestamp_start"] } == @start_event["@timestamp"]
             end
 
             it "contains an 'id field'" do
@@ -263,9 +263,9 @@ describe LogStash::Filters::Elapsed do
         insist { @filter.start_events.key?("3") } == false
       end
 
-      it "creates a new event with tag 'elapsed.expired_error' for each expired 'start event'" do
-        insist { @expired_events[0]["tags"].include?("elapsed.expired_error") } == true
-        insist { @expired_events[1]["tags"].include?("elapsed.expired_error") } == true
+      it "creates a new event with tag 'elapsed_expired_error' for each expired 'start event'" do
+        insist { @expired_events[0]["tags"].include?("elapsed_expired_error") } == true
+        insist { @expired_events[1]["tags"].include?("elapsed_expired_error") } == true
       end
 
       it "creates a new event with tag 'elapsed' for each expired 'start event'" do
@@ -278,14 +278,14 @@ describe LogStash::Filters::Elapsed do
         insist { @expired_events[1][ID_FIELD] } == "3"
       end
 
-      it "creates a new event containing an 'elapsed.time field' with the age of the expired 'start event'" do
-        insist { @expired_events[0]["elapsed.time"] } == 30
-        insist { @expired_events[1]["elapsed.time"] } == 31
+      it "creates a new event containing an 'elapsed_time field' with the age of the expired 'start event'" do
+        insist { @expired_events[0]["elapsed_time"] } == 30
+        insist { @expired_events[1]["elapsed_time"] } == 31
       end
 
-      it "creates a new event containing an 'elapsed.timestamp_start field' with the timestamp of the expired 'start event'" do
-        insist { @expired_events[0]["elapsed.timestamp_start"] } == @start_event_2["@timestamp"]
-        insist { @expired_events[1]["elapsed.timestamp_start"] } == @start_event_3["@timestamp"]
+      it "creates a new event containing an 'elapsed_timestamp_start field' with the timestamp of the expired 'start event'" do
+        insist { @expired_events[0]["elapsed_timestamp_start"] } == @start_event_2["@timestamp"]
+        insist { @expired_events[1]["elapsed_timestamp_start"] } == @start_event_3["@timestamp"]
       end
 
       it "creates a new event containing a 'host field' for each expired 'start event'" do


### PR DESCRIPTION
This fixes the plugin to be compatible with Elasticsearch 2.0,
but is a potentially breaking change for people currently using the plugin.

The documentation has been updated accordingly to reflect this.

The CHANGELOG has also been updated with the new version number (3.0.0)
to reflect this breaking change.

fixes #17