### PR TITLE
Allow option to customize timestamp fields

### DIFF
--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -16,6 +16,10 @@ require 'time'
 # The filter has been developed to track the execution time of processes and
 # other long tasks.
 #
+# The filter has been modified to allow specification of a timestamp to use
+# in determining the time interval between two events, instead of relying
+# on the timestamp logstash creates upon receiving and processing the event. 
+#
 # The configuration looks like this:
 # [source,ruby]
 #     filter {

--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -257,6 +257,7 @@ class LogStash::Filters::Elapsed < LogStash::Filters::Base
       event[ELAPSED_FIELD] = elapsed_time
       event[@unique_id_field] = unique_id
       event[TIMESTAMP_START_EVENT_FIELD] = Time.parse(timestamp_start_event)
+      event[TIMESTAMP_SINCE_EPOCH_START_EVENT_FIELD] = Time.parse(timestamp_start_event).to_f
 
       return event
   end

--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -227,7 +227,7 @@ class LogStash::Filters::Elapsed < LogStash::Filters::Base
       error_event[@unique_id_field] = element.event[@unique_id_field]
       error_event[ELAPSED_FIELD] = element.age
       error_event[TIMESTAMP_START_EVENT_FIELD] = Time.parse(element.event[@start_timestamp])
-      error_event[TIMESTAMP_SINCE_EPOCH_START_EVENT_FIELD] = Time.parse(element.event[@start_timestamp]).to_f
+      error_event[TIMESTAMP_SINCE_EPOCH_START_EVENT_FIELD] = DateTime.parse(element.event[@start_timestamp]).strftime('%Q').to_i
 
       events << error_event
       filter_matched(error_event)
@@ -257,7 +257,7 @@ class LogStash::Filters::Elapsed < LogStash::Filters::Base
       event[ELAPSED_FIELD] = elapsed_time
       event[@unique_id_field] = unique_id
       event[TIMESTAMP_START_EVENT_FIELD] = Time.parse(timestamp_start_event)
-      event[TIMESTAMP_SINCE_EPOCH_START_EVENT_FIELD] = Time.parse(timestamp_start_event).to_f
+      event[TIMESTAMP_SINCE_EPOCH_START_EVENT_FIELD] = DateTime.parse(timestamp_start_event).strftime('%Q').to_i
 
       return event
   end

--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -90,6 +90,7 @@ class LogStash::Filters::Elapsed < LogStash::Filters::Base
   PREFIX = "elapsed."
   ELAPSED_FIELD = PREFIX + "time"
   TIMESTAMP_START_EVENT_FIELD = PREFIX + "timestamp_start"
+  TIMESTAMP_SINCE_EPOCH_START_EVENT_FIELD = PREFIX + "timestamp_start_ts"
   HOST_FIELD = "host"
 
   ELAPSED_TAG = "elapsed"
@@ -226,6 +227,7 @@ class LogStash::Filters::Elapsed < LogStash::Filters::Base
       error_event[@unique_id_field] = element.event[@unique_id_field]
       error_event[ELAPSED_FIELD] = element.age
       error_event[TIMESTAMP_START_EVENT_FIELD] = Time.parse(element.event[@start_timestamp])
+      error_event[TIMESTAMP_SINCE_EPOCH_START_EVENT_FIELD] = Time.parse(element.event[@start_timestamp]).to_f
 
       events << error_event
       filter_matched(error_event)

--- a/spec/filters/elapsed_spec.rb
+++ b/spec/filters/elapsed_spec.rb
@@ -3,10 +3,13 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/elapsed"
 require "logstash/event"
 require "socket"
+require 'time'
 
 describe LogStash::Filters::Elapsed do
   START_TAG = "startTag"
+  START_TIMESTAMP = "start_timestamp"
   END_TAG   = "endTag"
+  END_TIMESTAMP = "end_timestamp"
   ID_FIELD  = "uniqueIdField"
 
   def event(data)
@@ -17,12 +20,14 @@ describe LogStash::Filters::Elapsed do
   def start_event(data)
     data["tags"] ||= []
     data["tags"] << START_TAG
+    data[START_TIMESTAMP] ||= "20150518-18:33:22.345"
     event(data)
   end
 
   def end_event(data = {})
     data["tags"] ||= []
     data["tags"] << END_TAG
+    data[END_TIMESTAMP] ||= "20150518-18:33:22.347"
     event(data)
   end
 
@@ -31,7 +36,7 @@ describe LogStash::Filters::Elapsed do
   end
 
   def setup_filter(config = {})
-    @config = {"start_tag" => START_TAG, "end_tag" => END_TAG, "unique_id_field" => ID_FIELD}
+    @config = {"start_tag" => START_TAG, "end_tag" => END_TAG, "unique_id_field" => ID_FIELD, "start_timestamp" => START_TIMESTAMP, "end_timestamp" => END_TIMESTAMP}
     @config.merge!(config)
     @filter = LogStash::Filters::Elapsed.new(@config)
     @filter.register
@@ -57,7 +62,7 @@ describe LogStash::Filters::Elapsed do
     describe "receiving an event with a valid start tag" do
       describe "but without an unique id field" do
         it "does not record it" do
-          @filter.filter(event("tags" => ["tag1", START_TAG]))
+          @filter.filter(event("tags" => ["tag1", START_TAG], START_TIMESTAMP => "20150518-18:33:22.345"))
           insist { @filter.start_events.size } == 0
         end
       end
@@ -75,7 +80,7 @@ describe LogStash::Filters::Elapsed do
 
     describe "receiving two 'start events' for the same id field" do
       it "keeps the first one and does not save the second one" do
-          args = {"tags" => [START_TAG], ID_FIELD => "id123"}
+          args = {"tags" => [START_TAG], ID_FIELD => "id123", START_TIMESTAMP => "20150518-18:33:22.345"}
           first_event = event(args)
           second_event = event(args)
 
@@ -100,7 +105,7 @@ describe LogStash::Filters::Elapsed do
 
       describe "and with an id" do
         describe "but without a previous 'start event'" do
-          it "adds a tag 'elapsed.end_witout_start' to the 'end event'" do
+          it "adds a tag 'elapsed.end_without_start' to the 'end event'" do
             end_event = end_event(ID_FIELD => "id_123")
 
             @filter.filter(end_event)
@@ -158,11 +163,11 @@ describe LogStash::Filters::Elapsed do
             end
 
             it "contains an 'elapsed.time field' with the elapsed time" do
-              insist { @match_event["elapsed.time"] } == 10
+              insist { @match_event["elapsed.time"] } == 0.002
             end
 
             it "contains an 'elapsed.timestamp_start field' with the timestamp of the 'start event'" do
-              insist { @match_event["elapsed.timestamp_start"] } == @start_event["@timestamp"]
+              insist { @match_event["elapsed.timestamp_start"] } == Time.parse(@start_event[START_TIMESTAMP])
             end
 
             it "contains an 'id field'" do
@@ -178,8 +183,8 @@ describe LogStash::Filters::Elapsed do
               @start_event = start_event(ID_FIELD => @id_value)
               @filter.filter(@start_event)
 
-              end_timestamp = @start_event["@timestamp"] + 10
-              end_event = end_event(ID_FIELD => @id_value, "@timestamp" => end_timestamp)
+              # end_timestamp = @start_event["@timestamp"] + 10
+              end_event = end_event(ID_FIELD => @id_value)
               @filter.filter(end_event) do |new_event|
                 @match_event = new_event
               end
@@ -196,8 +201,8 @@ describe LogStash::Filters::Elapsed do
 
           context "if 'new_event_on_match' is set to 'false'" do
             before(:each) do
-              end_timestamp = @start_event["@timestamp"] + 10
-              end_event = end_event(ID_FIELD => @id_value, "@timestamp" => end_timestamp)
+              # end_timestamp = @start_event["@timestamp"] + 10
+              end_event = end_event(ID_FIELD => @id_value)
               @filter.filter(end_event)
 
               @match_event = end_event
@@ -284,8 +289,8 @@ describe LogStash::Filters::Elapsed do
       end
 
       it "creates a new event containing an 'elapsed.timestamp_start field' with the timestamp of the expired 'start event'" do
-        insist { @expired_events[0]["elapsed.timestamp_start"] } == @start_event_2["@timestamp"]
-        insist { @expired_events[1]["elapsed.timestamp_start"] } == @start_event_3["@timestamp"]
+        insist { @expired_events[0]["elapsed.timestamp_start"] } == Time.parse(@start_event_2[START_TIMESTAMP])
+        insist { @expired_events[1]["elapsed.timestamp_start"] } == Time.parse(@start_event_3[START_TIMESTAMP])
       end
 
       it "creates a new event containing a 'host field' for each expired 'start event'" do


### PR DESCRIPTION
It is a requirement for us to be able to read a timestamp value from a logged message instead of relying on the global "timestamp" that appears in the log. This pull request allows for a custom start/end timestamp and defaults to the current "timestamp" if not provided.
