### PR TITLE
Enabled periodic flush so that the events can be expired

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,7 @@ Contributors:
 * Suyog Rao (suyograo)
 * karsaroth
 * Pere Urbón (purbon)
+* Artur Kronenberg (pandaadb)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -170,6 +170,11 @@ class LogStash::Filters::Elapsed < LogStash::Filters::Base
     end
   end # def filter
 
+  # Necessary to indicate logstash to periodically call 'flush' method
+  def periodic_flush
+    true
+  end
+
   # The method is invoked by LogStash every 5 seconds.
   def flush(options = {})
     expired_elements = []


### PR DESCRIPTION
Hi,

I believe this needs to be specifically enabled so that logstash will actually call flush. Currently the expiration of events does not seem to work. 

I noted the issue here: https://github.com/logstash-plugins/logstash-filter-elapsed/issues/22

Let me know if this is Ok/ needs changes.

Thanks,

Artur Kronenberg
