### PR TITLE
Remove comments causing docgen issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.1
+  - Docs: Fix docgen issues by removing extraneous comments
+
 # 4.0.0
   - Use the new Event Api used in v5.0.0+
 

--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -1,13 +1,7 @@
-# elapsed filter
-#
-# This filter tracks a pair of start/end events and calculates the elapsed
-# time between them.
-
 require "logstash/filters/base"
 require "logstash/namespace"
 require 'thread'
 require 'socket'
-
 
 # The elapsed filter tracks a pair of start/end events and uses their
 # timestamps to calculate the elapsed time between them.

--- a/logstash-filter-elapsed.gemspec
+++ b/logstash-filter-elapsed.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elapsed'
-  s.version         = '4.0.0'
+  s.version         = '4.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter tracks a pair of start/end events and calculates the elapsed time between them."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Removes the lines before the require statements [here](https://github.com/logstash-plugins/logstash-filter-elapsed/blob/master/lib/logstash/filters/elapsed.rb#L1) to fix the docgen issue described in https://github.com/elastic/logstash/issues/6692#issuecomment-279849370.
