### PR TITLE
Added option 'keep_start_event'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.0
+  - Added option `keep_start_event` to manage what to do when several messages matched
+  as a start event were received before the end event for the specified ID.
+  [#35](https://github.com/logstash-plugins/logstash-filter-elapsed/pull/35)
+
 ## 4.0.5
   - Fixed default to true for the periodic_flush option in order for the caching expiration to work [#36](https://github.com/logstash-plugins/logstash-filter-elapsed/pull/36) 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -106,6 +106,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-start_tag>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-unique_id_field>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-keep_start_event>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -162,6 +163,17 @@ The name of the field containing the task ID.
 This value must uniquely identify the task in the system, otherwise
 it's impossible to match the couple of events.
 
+[id="plugins-{type}s-{plugin}-keep_start_event"]
+===== `keep_start_event`
+
+  * Value type is <<string,string>>
+  * Default value is `first`
+
+This property manages what to do when several events matched as a start one
+were received before the end event for the specified ID. There are two
+supported values: `first` or `last`. If it's set to `first` (default value),
+the first event matched as a start will be used; if it's set to `last`,
+the last one will be used.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/logstash-filter-elapsed.gemspec
+++ b/logstash-filter-elapsed.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elapsed'
-  s.version         = '4.0.5'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Calculates the elapsed time between a pair of events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/elapsed_spec.rb
+++ b/spec/filters/elapsed_spec.rb
@@ -74,16 +74,36 @@ describe LogStash::Filters::Elapsed do
     end
 
     describe "receiving two 'start events' for the same id field" do
-      it "keeps the first one and does not save the second one" do
-          args = {"tags" => [START_TAG], ID_FIELD => "id123"}
-          first_event = event(args)
-          second_event = event(args)
+      context "if 'keep_start_event' is set to 'last'" do
+        before(:each) do
+          setup_filter("keep_start_event" => 'last')
+        end
 
-          @filter.filter(first_event)
-          @filter.filter(second_event)
+        it "keeps the second one and does not save the first one" do
+            args = {"tags" => [START_TAG], ID_FIELD => "id123"}
+            first_event = event(args)
+            second_event = event(args)
 
-          insist { @filter.start_events.size } == 1
-          insist { @filter.start_events["id123"].event } == first_event
+            @filter.filter(first_event)
+            @filter.filter(second_event)
+
+            insist { @filter.start_events.size } == 1
+            insist { @filter.start_events["id123"].event } == second_event
+        end
+      end
+
+      context "if 'keep_start_event' is set to 'first'" do
+        it "keeps the first one and does not save the second one" do
+            args = {"tags" => [START_TAG], ID_FIELD => "id123"}
+            first_event = event(args)
+            second_event = event(args)
+
+            @filter.filter(first_event)
+            @filter.filter(second_event)
+
+            insist { @filter.start_events.size } == 1
+            insist { @filter.start_events["id123"].event } == first_event
+        end
       end
     end
   end


### PR DESCRIPTION
The option 'keep_start_event' identifies the behavior in cases when several "start events" were received before an "end event". It's boolean value. If it's set to `first` (default value), the first "start event" will be used; if it's set to `last`, the last "start event" will be used.