### PR TITLE
enable periodic flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.5
+  - Fixed default to true for the periodic_flush option in order for the caching expiration to work [#36](https://github.com/logstash-plugins/logstash-filter-elapsed/pull/36) 
+
 ## 4.0.4
   - Update gemspec summary
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,7 @@ Contributors:
 * Suyog Rao (suyograo)
 * karsaroth
 * Pere Urbón (purbon)
+* Colin Surprenant (colinsurprenant)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -109,6 +109,10 @@ class LogStash::Filters::Elapsed < LogStash::Filters::Base
   # to the "end event"; if it's set to `true` a new "match event" is created.
   config :new_event_on_match, :validate => :boolean, :required => false, :default => false
 
+  # This filter must have its flush function called periodically to be able to purge
+  # expired stored start events.
+  config :periodic_flush, :validate => :boolean, :default => true
+
   public
   def register
     @mutex = Mutex.new

--- a/logstash-filter-elapsed.gemspec
+++ b/logstash-filter-elapsed.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elapsed'
-  s.version         = '4.0.4'
+  s.version         = '4.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Calculates the elapsed time between a pair of events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This puts back the `periodic_flush` option to a default of true so that the filter periodic flusher `flush` method is called by the pipeline to support the events cache expiration.
