### PR TITLE
Fix ruby source block with blank lines

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -48,6 +48,7 @@ particular task. The name of this field is stored in `unique_id_field`.
 You can use a Grok filter to prepare the events for the elapsed filter.
 An example of configuration can be:
 [source,ruby]
+----
     filter {
       grok {
         match => { "message" => "%{TIMESTAMP_ISO8601} START id: (?<task_id>.*)" }
@@ -65,6 +66,7 @@ An example of configuration can be:
         unique_id_field => "task_id"
       }
     }
+----
 
 The elapsed filter collects all the "start events". If two, or more, "start
 events" have the same ID, only the first one is recorded, the others are


### PR DESCRIPTION
Added start and end markers to source block containing blank lines, so that it is correctly presented.
