### PR TITLE
fix(docs): Fix block code

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -53,12 +53,10 @@ An example of configuration can be:
         match => { "message" => "%{TIMESTAMP_ISO8601} START id: (?<task_id>.*)" }
         add_tag => [ "taskStarted" ]
       }
-
       grok {
         match => { "message" => "%{TIMESTAMP_ISO8601} END id: (?<task_id>.*)" }
         add_tag => [ "taskTerminated" ]
       }
-
       elapsed {
         start_tag => "taskStarted"
         end_tag => "taskTerminated"


### PR DESCRIPTION
Fix block code.

The description documentation is not really easy to read as the block code is stopped on first empty line.
https://www.elastic.co/guide/en/logstash/current/plugins-filters-elapsed.html#_description_123
Here a fix to allow the block code to be seen entirely !
