### PR TITLE
[docs] Fix malformed example

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -48,6 +48,7 @@ particular task. The name of this field is stored in `unique_id_field`.
 You can use a Grok filter to prepare the events for the elapsed filter.
 An example of configuration can be:
 [source,ruby]
+--------------------------------------------------
     filter {
       grok {
         match => { "message" => "%{TIMESTAMP_ISO8601} START id: (?<task_id>.*)" }
@@ -65,6 +66,7 @@ An example of configuration can be:
         unique_id_field => "task_id"
       }
     }
+--------------------------------------------------
 
 The elapsed filter collects all the "start events". If two, or more, "start
 events" have the same ID, only the first one is recorded, the others are


### PR DESCRIPTION
The docs at https://www.elastic.co/guide/en/logstash/current/plugins-filters-elapsed.html#_description_128 have a formatting issue in the example box, resulting in the example being ripped apart. This PR should fix it.

<img width="765" alt="Screenshot 2022-07-11 at 14 55 44" src="https://user-images.githubusercontent.com/55087308/178269129-c620fe15-c1e4-443d-a859-9e367508bf6e.png">

